### PR TITLE
A patch D::L::Gettext::Parser handles  msgid and msgstr including escaped quotes

### DIFF
--- a/lib/Data/Localize/Gettext/Parser.pm
+++ b/lib/Data/Localize/Gettext/Parser.pm
@@ -87,7 +87,7 @@ sub _process_block {
 
     return if $is_fuzzy && ! $self->use_fuzzy();
 
-    s/\\(n|\\)/$1 eq 'n' ? "\n" : "\\" /ge for $msgid, $msgstr;
+    s/\\(n|\\|\")/ $1 eq 'n'  ? "\n" : $1 eq '\\' ? "\\" : '"' /ge for $msgid, $msgstr;
 
     $lexicons->{$msgid} = $msgstr;
 

--- a/t/07_gettext_parser.t
+++ b/t/07_gettext_parser.t
@@ -1,7 +1,7 @@
 use strict;
 use utf8;
 use t::Data::Localize::Test qw(write_po);
-use Test::More tests => 6;
+use Test::More tests => 7;
 use Data::Localize::Gettext::Parser;
 
 {
@@ -137,3 +137,24 @@ EOM
 }
 
 
+{
+    my $file = write_po( <<'EOM' );
+msgid "This is \"quote\"."
+msgstr "C'est \"citation\"."
+
+EOM
+
+    my $parser = Data::Localize::Gettext::Parser->new(
+        encoding   => 'utf-8',
+        use_fuzzy  => 0,
+        keep_empty => 0,
+    );
+
+    my $lexicon = $parser->parse_file($file);
+
+    is_deeply(
+        $lexicon,
+        { 'This is "quote".' => q{C'est "citation".} },
+        'parsing a po file with a dobule-quotation marks contained data'
+    );
+}


### PR DESCRIPTION
I think that Data::Localize::Gettext::Parser doesn't handle msgid and msgstr including escaped quotes well.
# like that

msgid "a\"b"
msgstr "A\"B"
