### PR TITLE
Fix broken usage of isa => 'ArrayRef'

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,6 +5,7 @@ name('Data-Localize');
 all_from('lib/Data/Localize.pm');
 
 requires 'Moo' => '1.000008';
+requires 'MooX::Types::MooseLike::Base';
 requires 'Encode';
 requires 'I18N::LangTags';
 requires 'I18N::LangTags::Detect';

--- a/lib/Data/Localize/MultiLevel.pm
+++ b/lib/Data/Localize/MultiLevel.pm
@@ -2,6 +2,7 @@ package Data::Localize::MultiLevel;
 use Moo;
 use Config::Any;
 use Data::Localize;
+use MooX::Types::MooseLike::Base qw(ArrayRef);
 BEGIN {
     if (Data::Localize::DEBUG) {
         require Data::Localize::Log;
@@ -14,7 +15,7 @@ with 'Data::Localize::Trait::WithStorage';
 
 has paths => (
     is => 'ro',
-    isa => 'ArrayRef',
+    isa => ArrayRef,
     trigger => sub {
         my $self = shift;
         $self->load_from_path($_) for @{$_[0]};


### PR DESCRIPTION
Moo doesn't have a built in type library, so isa => 'ArrayRef' isn't valid.  This changes it to use the type from MooX::Types::MooseLike.
