### PR TITLE
NamedArgs.pm: Allow to work with 5.20 and above

### DIFF
--- a/lib/Data/Localize/Format/NamedArgs.pm
+++ b/lib/Data/Localize/Format/NamedArgs.pm
@@ -8,7 +8,7 @@ sub format {
 
     return $value unless ref $args eq 'HASH';
 
-    $value =~ s/{{([^}]+)}}/ $args->{ $1 } || '' /ex;
+    $value =~ s/\{\{([^}]+)\}\}/ $args->{ $1 } || '' /ex;
     return $value;
 }
 


### PR DESCRIPTION
Left braces "{" that are used literally will eventually need to be
escaped, most simply by preceding them with a backslash.  In the
meantime, their use raises a deprecation warning starting in Perl v5.21.2.  See
https://rt.perl.org/Ticket/Display.html?id=122146

Right braces don't need this, but no harm is done by adding backslashes,
and the resulting symmetry may prevent confusion, so this commit adds
those as well.  Feel free to remove them if that is your preference.

I have been unable to get this to fail (prior to this commit) locally.  The ticket indicates YAML::XS or BerkeleyDb need to be installed first to get the failure, but doing so didn't cause a failure for me.  So I patched based on the printout from the CPAN tester report
http://www.cpantesters.org/cpan/report/9fb99cfc-f85c-11e3-b74a-1c9f0a370852
I have tested that the changed regular expression properly compiles and does not generate a message, but I haven't actually been able to test that this fix causes the CPAN test to succeed
