### PR TITLE
Bugfix: multiple nameded arguments now possible

### DIFF
--- a/lib/Data/Localize/Format/NamedArgs.pm
+++ b/lib/Data/Localize/Format/NamedArgs.pm
@@ -8,7 +8,7 @@ sub format {
 
     return $value unless ref $args eq 'HASH';
 
-    $value =~ s/\{\{([^}]+)\}\}/ $args->{ $1 } || '' /ex;
+    $value =~ s/\{\{([^}]+)\}\}/ $args->{ $1 } || '' /gex;
     return $value;
 }
 

--- a/t/08_multilevel.t
+++ b/t/08_multilevel.t
@@ -39,4 +39,12 @@ $loc->add_localizer(
     is( $loc->localize( 'nonexistent.hello_world' ), 'nonexistent.hello_world' );
 }
 
+{
+    $loc->set_languages('en');
+    is( $loc->localize( 'multi_greet.hello', { man => 'John Doe', woman => 'Jane Roe' } ), 'Hello, Mr. John Doe and  Ms. Jane Roe', "multi_greet.hello (en)" );
+    is( $loc->localize( 'multi_greet.morning', { man => 'John Doe', woman => 'Jane Roe' } ), 'Good morning, Mr. John Doe and Ms. Jane Roe', "multi_greet.morning (en)" );
+    is( $loc->localize( 'multi_greet.afternoon', { man => 'John Doe', woman => 'Jane Roe' } ), 'Good afternoon, Mr. John Doe and Ms. Jane Roe', "multi_greet.afternoon (en)" );
+    is( $loc->localize( 'multi_greet.evening', { man => 'John Doe', woman => 'Jane Roe' } ), 'Good evening, Mr. John Doe and Ms. Jane Roe', "multi_greet.evening (en)" );
+}
+
 done_testing;

--- a/t/08_multilevel/en.yml
+++ b/t/08_multilevel/en.yml
@@ -5,3 +5,9 @@ en:
         morning: 'Good morning, {{name}}'
         afternoon: 'Good afternoon, {{name}}'
         evening: 'Good evening, {{name}}'
+    multi_greet:
+        hello: 'Hello, Mr. {{man}} and  Ms. {{woman}}'
+        morning: 'Good morning, Mr. {{man}} and Ms. {{woman}}'
+        afternoon: 'Good afternoon, Mr. {{man}} and Ms. {{woman}}'
+        evening: 'Good evening, Mr. {{man}} and Ms. {{woman}}'
+


### PR DESCRIPTION
The original regex in ```NamedArgs.pm``` didn't match for all possible occurrences, instead it took only the first match. This made multiple named arguments impossible to localize.

Fixed the regex and wrote unit-tests for it.